### PR TITLE
fix(deps): upgrade to AsciidoctorJ 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
   </scm>
 
     <properties>
-        <asciidoctorj.version>2.5.13</asciidoctorj.version>
-        <asciidoctor.maven.version>3.0.0</asciidoctor.maven.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
+        <asciidoctor.maven.version>3.1.1</asciidoctor.maven.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- SonarQube -->

--- a/src/it/asciidoc-confluence-publisher-maven-plugin/pom.xml
+++ b/src/it/asciidoc-confluence-publisher-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.sahli.asciidoc.confluence.publisher</groupId>
                 <artifactId>asciidoc-confluence-publisher-maven-plugin</artifactId>
-                <version>0.19.0</version>
+                <version>0.25.0</version>
                 <configuration>
                     <rootConfluenceUrl>https://my-confluence</rootConfluenceUrl>
                     <username>username</username>

--- a/src/it/asciidoc-confluence-publisher-maven-plugin/pom.xml
+++ b/src/it/asciidoc-confluence-publisher-maven-plugin/pom.xml
@@ -68,11 +68,6 @@
                         <artifactId>@project.artifactId@</artifactId>
                         <version>@project.version@</version>
                     </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>2.5.9</version>
-                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>

--- a/src/main/java/org/jqassistant/tooling/asciidoctorj/processors/pre/IconEnabler.java
+++ b/src/main/java/org/jqassistant/tooling/asciidoctorj/processors/pre/IconEnabler.java
@@ -6,6 +6,7 @@ import io.smallrye.common.constraint.NotNull;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.extension.Reader;
 import org.jqassistant.tooling.asciidoctorj.freemarker.TemplateRepo;
 import org.jqassistant.tooling.asciidoctorj.processors.attributes.ProcessAttributes;
 import org.jqassistant.tooling.asciidoctorj.processors.attributes.ProcessAttributesFactory;
@@ -27,7 +28,7 @@ public class IconEnabler extends Preprocessor {
     }
 
     @Override
-    public void process(Document document, PreprocessorReader reader) {
+    public Reader process(Document document, PreprocessorReader reader) {
         ProcessAttributes attributes = ProcessAttributesFactory.createProcessAttributesPre(document);
 
         Writer writer = new StringWriter();
@@ -47,5 +48,6 @@ public class IconEnabler extends Preprocessor {
         reader.restoreLines(lines);
 
         LOGGER.debug("Added icon configuration to top of the adoc");
+        return reader;
     }
 }


### PR DESCRIPTION
AsciidoctorJ 3.0 contains a breaking change regarding Preprocessor API, allowing a preprocessor to return a reader

Fixes #23