### PR TITLE
chore(deps): remove explicit snakeyaml dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,6 @@
             <version>${asciidoctorj.version}</version>
         </dependency>
         <dependency>
-            <!-- required by JRuby, cannot handle Snakeyaml 2.0 -->
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.3</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>2.3.33</version>


### PR DESCRIPTION
Since there's no reason anymore to fix the version, the explicit dependency declaration can be removed